### PR TITLE
Export createjs object, and also import Image class into Bitmap

### DIFF
--- a/src/easeljs/display/Bitmap.js
+++ b/src/easeljs/display/Bitmap.js
@@ -26,6 +26,9 @@
 * OTHER DEALINGS IN THE SOFTWARE.
 */
 
+var Canvas = require('canvas');
+var Image = Canvas.Image;
+
 // namespace:
 this.createjs = this.createjs||{};
 

--- a/src/node-easel.js
+++ b/src/node-easel.js
@@ -133,3 +133,5 @@ createjs.Ticker.halt = function() {
 		clearTimeout(createjs.Ticker.timeoutID);
 	}
 }
+
+module.exports.createjs = createjs;


### PR DESCRIPTION
In my code, I was doing this:

```
require('node-easel');
```

and later on, and in another file, doing this:

```
new createjs.Bitmap(...
```

This call failed in Bitmap.js, claiming that it couldn't find the Image class. I've added a require into Bitmap.js so that it explicitely references the canvas Image class.

Also, I had problems if require('node-easel') appeared in more than one file. In this case, only the first file would see the global createjs object. Why this should be I'm not sure, but it describes the symptoms if not the cause.

I've added a line to node-easel.js to export the object in a more node/CommonJS like way so the require becomes

```
var createjs = require('node-easel').createjs;
```
